### PR TITLE
feat: implement file watcher core

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width=64

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ use crate::entry::WatchrEntry;
 )]
 pub struct Cli {
     #[command(subcommand)]
-    pub commands: Command,
+    pub command: Commands,
 }
 
 #[derive(Error, Debug)]
@@ -22,7 +22,7 @@ pub enum CliError {
 }
 
 #[derive(Subcommand)]
-pub enum Command {
+pub enum Commands {
     /// Generate config file
     Init,
 
@@ -48,11 +48,11 @@ pub enum Command {
     },
 }
 
-impl Command {
+impl Commands {
     pub fn to_entry(&self) -> Result<Option<WatchrEntry>, CliError> {
         match self {
-            Command::Init => Ok(None),
-            Command::Watch { dir, ext, cmd, .. } => {
+            Commands::Init => Ok(None),
+            Commands::Watch { dir, ext, cmd, .. } => {
                 let ext = ext
                     .as_ref()
                     .map(|ext| ext.split(',').map(|x| x.to_string()).collect());
@@ -78,8 +78,8 @@ impl Command {
 
     pub fn config_path(&self) -> Option<&Path> {
         match self {
-            Command::Init => None,
-            Command::Watch { config, .. } => config.as_ref().map(|c| c.as_path()),
+            Commands::Init => None,
+            Commands::Watch { config, .. } => config.as_ref().map(|c| c.as_path()),
         }
     }
 }
@@ -90,13 +90,13 @@ mod tests {
 
     #[test]
     fn test_to_entry_init() {
-        let init = Command::Init;
+        let init = Commands::Init;
         assert!(init.to_entry().unwrap().is_none());
     }
 
     #[test]
     fn test_to_entry_watch_dir_none() {
-        let watch = Command::Watch {
+        let watch = Commands::Watch {
             dir: None,
             ext: None,
             config: None,
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn test_to_entry_cmd_dir_none() {
-        let watch = Command::Watch {
+        let watch = Commands::Watch {
             dir: None,
             ext: None,
             config: None,
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn test_to_entry_cmd_none() {
-        let watch = Command::Watch {
+        let watch = Commands::Watch {
             dir: Some(PathBuf::from("./")),
             ext: None,
             config: None,
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn test_to_entry_happy_path() {
-        let watch = Command::Watch {
+        let watch = Commands::Watch {
             dir: Some(PathBuf::from("./")),
             ext: None,
             config: None,
@@ -148,13 +148,13 @@ mod tests {
 
     #[test]
     fn test_config_path_init() {
-        let init = Command::Init;
+        let init = Commands::Init;
         assert!(init.config_path().is_none());
     }
 
     #[test]
     fn test_config_path_watch_config_none() {
-        let watch = Command::Watch {
+        let watch = Commands::Watch {
             dir: None,
             ext: None,
             cmd: None,
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_config_path_watch_config_is_not_none() {
-        let watch = Command::Watch {
+        let watch = Commands::Watch {
             dir: None,
             ext: None,
             cmd: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,18 +49,24 @@ pub enum Commands {
 }
 
 impl Commands {
-    pub fn to_entry(&self) -> Result<Option<WatchrEntry>, CliError> {
+    pub fn to_entry(
+        &self,
+    ) -> Result<Option<WatchrEntry>, CliError> {
         match self {
             Commands::Init => Ok(None),
             Commands::Watch { dir, ext, cmd, .. } => {
-                let ext = ext
-                    .as_ref()
-                    .map(|ext| ext.split(',').map(|x| x.to_string()).collect());
+                let ext = ext.as_ref().map(|ext| {
+                    ext.split(',')
+                        .map(|x| x.to_string())
+                        .collect()
+                });
 
                 let dir = dir.as_ref();
                 let cmd = cmd.as_ref();
 
-                if (dir.is_none() && cmd.is_some()) || (cmd.is_none() && dir.is_some()) {
+                if (dir.is_none() && cmd.is_some())
+                    || (cmd.is_none() && dir.is_some())
+                {
                     Err(CliError::MalformedEntry)
                 } else if dir.is_some() && cmd.is_some() {
                     Ok(Some(WatchrEntry {
@@ -79,7 +85,9 @@ impl Commands {
     pub fn config_path(&self) -> Option<&Path> {
         match self {
             Commands::Init => None,
-            Commands::Watch { config, .. } => config.as_ref().map(|c| c.as_path()),
+            Commands::Watch { config, .. } => {
+                config.as_ref().map(|c| c.as_path())
+            }
         }
     }
 }
@@ -102,7 +110,10 @@ mod tests {
             config: None,
             cmd: Some("cargo test".to_string()),
         };
-        assert!(matches!(watch.to_entry(), Err(CliError::MalformedEntry)));
+        assert!(matches!(
+            watch.to_entry(),
+            Err(CliError::MalformedEntry)
+        ));
     }
 
     #[test]
@@ -124,7 +135,10 @@ mod tests {
             config: None,
             cmd: None,
         };
-        assert!(matches!(watch.to_entry(), Err(CliError::MalformedEntry)));
+        assert!(matches!(
+            watch.to_entry(),
+            Err(CliError::MalformedEntry)
+        ));
     }
 
     #[test]
@@ -171,6 +185,9 @@ mod tests {
             cmd: None,
             config: Some(PathBuf::from("./")),
         };
-        assert_eq!(watch.config_path(), Some(PathBuf::from("./").as_path()));
+        assert_eq!(
+            watch.config_path(),
+            Some(PathBuf::from("./").as_path())
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,9 @@ fn default_debounce_ms() -> u64 {
     500
 }
 
-pub fn read_config(path: &Path) -> Result<WatchrConfig, ConfigError> {
+pub fn read_config(
+    path: &Path,
+) -> Result<WatchrConfig, ConfigError> {
     let config_str = fs::read_to_string(path)?;
     let config: WatchrConfig = toml::from_str(&config_str)?;
     Ok(config)
@@ -39,7 +41,8 @@ mod tests {
     use super::*;
 
     fn create_config_file(path: &Path, malformed: bool) {
-        let injection = (if malformed { "[" } else { "" }).to_string();
+        let injection =
+            (if malformed { "[" } else { "" }).to_string();
 
         let config = format!(
             r####"{}debounce_ms = 500
@@ -96,6 +99,9 @@ command = "pwd"
         create_config_file(&file_path, true);
 
         let result = read_config(&file_path);
-        assert!(matches!(result, Err(ConfigError::Deserialize(_))));
+        assert!(matches!(
+            result,
+            Err(ConfigError::Deserialize(_))
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 mod config;
 mod entry;
 mod resolver;
+mod watcher;
 
 fn main() {
     println!("Hello, world!");

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -8,7 +8,9 @@ pub enum ResolverError {
     NotFound,
 }
 
-pub fn find_config_file(path: &Path) -> Result<PathBuf, ResolverError> {
+pub fn find_config_file(
+    path: &Path,
+) -> Result<PathBuf, ResolverError> {
     let mut current = path.to_path_buf();
 
     loop {

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,11 +1,21 @@
+use std::path::PathBuf;
 use std::process;
-use std::sync::mpsc;
+use std::sync::mpsc::{
+    Receiver, Sender, channel as mpsc_channel,
+};
 use std::time::Duration;
 
-use notify_debouncer_full::{DebounceEventResult, new_debouncer, notify, notify::RecursiveMode};
+use notify_debouncer_full::notify::{
+    RecommendedWatcher, RecursiveMode,
+};
+use notify_debouncer_full::{
+    DebounceEventResult, Debouncer, NoCache, new_debouncer,
+    notify,
+};
 use thiserror::Error;
 
 use crate::config::WatchrConfig;
+use crate::entry::WatchrEntry;
 
 #[derive(Error, Debug)]
 pub enum WatcherError {
@@ -19,59 +29,109 @@ pub enum WatchEvent {
     Shutdown,
 }
 
-pub fn run_watch(config: WatchrConfig) -> Result<(), WatcherError> {
-    let (tx, rx) = mpsc::channel();
-    let mut debouncers = Vec::new();
-
-    for entry in config.entries {
-        let tx = tx.clone();
-
-        let mut debouncer = new_debouncer(
-            Duration::from_millis(config.debounce_ms),
-            None,
-            move |result: DebounceEventResult| match result {
-                Ok(events) => {
-                    for event in events {
-                        for path in event.paths.clone() {
-                            if !path.is_file() {
-                                continue;
-                            }
-                            if entry.ext.is_none() {
-                                let _ = tx.send(WatchEvent::Command(entry.command.clone()));
-                                continue;
-                            }
-
-                            let ext = path.extension();
-                            for ext_ in entry.ext.clone().unwrap() {
-                                if ext_ == ext.unwrap().display().to_string() {
-                                    let _ = tx.send(WatchEvent::Command(entry.command.clone()));
-                                }
-                            }
-                        }
-                    }
-                }
-                Err(errors) => {
-                    for e in errors {
-                        println!("{:?}", e);
-                    }
-                }
-            },
-        )?;
-
-        for dir in entry.dirs {
-            let dir = dir.clone();
-            debouncer.watch(dir, RecursiveMode::Recursive)?;
-        }
-        debouncers.push(debouncer);
-    }
+pub fn run_watch(
+    config: WatchrConfig,
+) -> Result<(), WatcherError> {
+    let (tx, rx) = mpsc_channel();
+    let _debouncers = create_debouncers(
+        config.debounce_ms,
+        config.entries,
+        tx.clone(),
+    )?;
 
     // drop initial sender after creating clones
     drop(tx);
 
+    run_event_loop(rx);
+    Ok(())
+}
+
+fn handle_events(
+    result: DebounceEventResult,
+    exts: Option<Vec<String>>,
+    command: String,
+    tx: Sender<WatchEvent>,
+) {
+    match result {
+        Ok(events) => {
+            if exts.as_ref().is_none() {
+                let _ = tx
+                    .send(WatchEvent::Command(command.clone()));
+                return;
+            }
+
+            let paths: Vec<PathBuf> = events
+                .into_iter()
+                .flat_map(|event| event.paths.clone())
+                .collect();
+
+            for path in paths {
+                if !path.is_file() {
+                    continue;
+                }
+
+                if let (Some(ext), Some(exts)) = (
+                    path.extension().and_then(|e| e.to_str()),
+                    exts.as_deref(),
+                ) && exts.iter().any(|e| e == ext)
+                {
+                    let _ = tx.send(WatchEvent::Command(
+                        command.clone(),
+                    ));
+                    return;
+                }
+            }
+        }
+        Err(errors) => {
+            for e in errors {
+                println!("{:?}", e);
+            }
+        }
+    }
+}
+
+fn create_debouncers(
+    debounce_ms: u64,
+    entries: Vec<WatchrEntry>,
+    tx: Sender<WatchEvent>,
+) -> Result<
+    Vec<Debouncer<RecommendedWatcher, NoCache>>,
+    WatcherError,
+> {
+    let mut debouncers = Vec::new();
+    for entry in entries {
+        let tx = tx.clone();
+
+        let mut debouncer = new_debouncer(
+            Duration::from_millis(debounce_ms),
+            None,
+            move |result: DebounceEventResult| {
+                handle_events(
+                    result,
+                    entry.ext.clone(),
+                    entry.command.clone(),
+                    tx.clone(),
+                );
+            },
+        )?;
+
+        for dir in &entry.dirs {
+            debouncer.watch(dir, RecursiveMode::Recursive)?;
+        }
+        debouncers.push(debouncer);
+    }
+    Ok(debouncers)
+}
+
+fn run_event_loop(rx: Receiver<WatchEvent>) {
     loop {
         match rx.recv() {
             Ok(WatchEvent::Command(cmd)) => {
-                let output = process::Command::new("sh").arg("-c").arg(&cmd).output();
+                let output = process::Command::new("sh")
+                    .arg("-c")
+                    .arg(&cmd)
+                    .output();
+
                 match output {
                     Ok(out) => println!("{:?}", out),
                     Err(e) => println!("{:?}", e),
@@ -81,5 +141,4 @@ pub fn run_watch(config: WatchrConfig) -> Result<(), WatcherError> {
             Err(_) => break,
         }
     }
-    Ok(())
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -142,3 +142,90 @@ fn run_event_loop(rx: Receiver<WatchEvent>) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use std::time::Instant;
+
+    use notify_debouncer_full::DebouncedEvent;
+    use notify_debouncer_full::notify::ErrorKind;
+    use notify_debouncer_full::notify::event::{
+        Event, EventKind, ModifyKind,
+    };
+
+    fn create_debounced_event_result(
+        error: bool,
+    ) -> DebounceEventResult {
+        if error {
+            return Err(vec![notify::Error {
+                kind: ErrorKind::Generic("custom".to_string()),
+                paths: vec![PathBuf::from("./")],
+            }]);
+        }
+
+        Ok(vec![DebouncedEvent {
+            event: Event {
+                kind: EventKind::Modify(ModifyKind::Any),
+                paths: vec![PathBuf::from("src/main.rs")],
+                attrs: Default::default(),
+            },
+            time: Instant::now(),
+        }])
+    }
+
+    #[test]
+    fn test_handle_events_no_ext() {
+        let result = create_debounced_event_result(false);
+        let (tx, rx) = mpsc_channel();
+        handle_events(result, None, "pwd".to_string(), tx);
+
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(WatchEvent::Command(_))
+        ));
+    }
+
+    #[test]
+    fn test_handle_event_matching_ext() {
+        let result = create_debounced_event_result(false);
+        let (tx, rx) = mpsc_channel();
+        handle_events(
+            result,
+            Some(vec!["rs".to_string()]),
+            "pwd".to_string(),
+            tx,
+        );
+
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(WatchEvent::Command(_))
+        ));
+    }
+
+    #[test]
+    fn test_handle_event_no_matching_ext() {
+        let result = create_debounced_event_result(false);
+        let (tx, rx) = mpsc_channel();
+        handle_events(
+            result,
+            Some(vec!["txt".to_string()]),
+            "pwd".to_string(),
+            tx,
+        );
+
+        // mpsc::TryRecvError::Empty
+        assert!(matches!(rx.try_recv(), Err(..)));
+    }
+
+    #[test]
+    fn test_hand_event_error_result() {
+        let result = create_debounced_event_result(true);
+        let (tx, rx) = mpsc_channel();
+        handle_events(result, None, "pwd".to_string(), tx);
+
+        // mpsc::TryRecvError::Empty
+        assert!(matches!(rx.try_recv(), Err(..)))
+    }
+}

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,0 +1,85 @@
+use std::process;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use notify_debouncer_full::{DebounceEventResult, new_debouncer, notify, notify::RecursiveMode};
+use thiserror::Error;
+
+use crate::config::WatchrConfig;
+
+#[derive(Error, Debug)]
+pub enum WatcherError {
+    #[error("notify-debouncer error: {0}")]
+    Notify(#[from] notify::Error),
+}
+
+#[derive(Debug)]
+pub enum WatchEvent {
+    Command(String),
+    Shutdown,
+}
+
+pub fn run_watch(config: WatchrConfig) -> Result<(), WatcherError> {
+    let (tx, rx) = mpsc::channel();
+    let mut debouncers = Vec::new();
+
+    for entry in config.entries {
+        let tx = tx.clone();
+
+        let mut debouncer = new_debouncer(
+            Duration::from_millis(config.debounce_ms),
+            None,
+            move |result: DebounceEventResult| match result {
+                Ok(events) => {
+                    for event in events {
+                        for path in event.paths.clone() {
+                            if !path.is_file() {
+                                continue;
+                            }
+                            if entry.ext.is_none() {
+                                let _ = tx.send(WatchEvent::Command(entry.command.clone()));
+                                continue;
+                            }
+
+                            let ext = path.extension();
+                            for ext_ in entry.ext.clone().unwrap() {
+                                if ext_ == ext.unwrap().display().to_string() {
+                                    let _ = tx.send(WatchEvent::Command(entry.command.clone()));
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(errors) => {
+                    for e in errors {
+                        println!("{:?}", e);
+                    }
+                }
+            },
+        )?;
+
+        for dir in entry.dirs {
+            let dir = dir.clone();
+            debouncer.watch(dir, RecursiveMode::Recursive)?;
+        }
+        debouncers.push(debouncer);
+    }
+
+    // drop initial sender after creating clones
+    drop(tx);
+
+    loop {
+        match rx.recv() {
+            Ok(WatchEvent::Command(cmd)) => {
+                let output = process::Command::new("sh").arg("-c").arg(&cmd).output();
+                match output {
+                    Ok(out) => println!("{:?}", out),
+                    Err(e) => println!("{:?}", e),
+                }
+            }
+            Ok(WatchEvent::Shutdown) => {}
+            Err(_) => break,
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## What
Implement core logic for `watchr`, watching files and executing 
a specified command on change to any file in the directory.

## Changes
- Implemented `run_watch` orchestrator
- Extracted `create_debouncers`, `handle_events`, `run_event_loop`
- Add extension filtering logic
- Add unit tests for handle events

## Impact
No changes in runtime behavior. `watcher` module is now
available for use with subsequent issues.

## Checklist:
- [x] All tests pass
- [x] CI green
- [x] Closes #6 