### PR TITLE
feat: implement watchr init command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,6 +90,13 @@ impl Commands {
             }
         }
     }
+
+    pub fn is_init(&self) -> bool {
+        match self {
+            Commands::Init => true,
+            Commands::Watch { .. } => false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -189,5 +196,22 @@ mod tests {
             watch.config_path(),
             Some(PathBuf::from("./").as_path())
         );
+    }
+
+    #[test]
+    fn test_is_init_true() {
+        let init = Commands::Init;
+        assert!(init.is_init());
+    }
+
+    #[test]
+    fn test_is_init_false() {
+        let watch = Commands::Watch {
+            dir: None,
+            ext: None,
+            cmd: None,
+            config: None,
+        };
+        assert!(!watch.is_init());
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,46 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum InitError {
+    #[error(".watchr.toml already exists")]
+    FileAlreadyExists,
+
+    #[error("IoError: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+const DEFAULT_CONFIG_TEMPLATE: &str = r#"
+# watchr configuration file
+# Debounce time in milliseconds (default: 500)
+debounce_ms = 500
+
+# Example watcher entry
+# [[watcher]]
+# name = "tests"
+# dirs = ["src/", "tests/"]
+# ext = ["rs", "toml"]
+# command = "cargo test"
+
+# Multiple watchers can be defined
+# [[watcher]]
+# name = "lint"
+# dirs = ["src/"]
+# command = "cargo clippy"
+"#;
+
+pub fn run_init(path: &Path) -> Result<(), InitError> {
+    let path = path.join(".watchr.toml");
+    if path.exists() {
+        return Err(InitError::FileAlreadyExists);
+    }
+
+    let mut file = File::create(path)?;
+
+    file.write_all(DEFAULT_CONFIG_TEMPLATE.as_bytes())?;
+    file.flush()?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 mod cli;
 mod config;
 mod entry;
+mod init;
 mod resolver;
 mod watcher;
 
@@ -12,6 +13,7 @@ use thiserror::Error;
 
 use crate::cli::{Cli, CliError};
 use crate::config::{ConfigError, WatchrConfig, read_config};
+use crate::init::{InitError, run_init};
 use crate::resolver::{ResolverError, find_config_file};
 use crate::watcher::{WatcherError, run_watch};
 
@@ -37,6 +39,9 @@ enum MainError {
 
     #[error("Directory not found: {0}")]
     DirNotFound(PathBuf),
+
+    #[error("InitError: {0}")]
+    InitError(#[from] InitError),
 }
 
 fn main() {
@@ -49,40 +54,47 @@ fn main() {
 fn run() -> Result<(), MainError> {
     let cli = Cli::parse();
 
-    let cli_entry = cli.command.to_entry()?;
-    let mut config_path =
-        cli.command.config_path().map(|p| p.to_path_buf());
-
-    if config_path.is_none() {
-        config_path =
-            find_config_file(&std::env::current_dir()?).ok();
-    }
-
-    let config = if let Some(config_path) = config_path {
-        read_config(config_path.as_path())?
-    } else if let Some(entry) = cli_entry {
-        WatchrConfig {
-            debounce_ms: 500,
-            entries: vec![entry],
-        }
+    if cli.command.is_init() {
+        run_init(&std::env::current_dir()?)?;
+        println!(".watchr.toml created");
     } else {
-        return Err(MainError::NoWatcherEntriesProvided);
-    };
+        let cli_entry = cli.command.to_entry()?;
+        let mut config_path =
+            cli.command.config_path().map(|p| p.to_path_buf());
 
-    if config.entries.is_empty() {
-        return Err(MainError::NoWatcherEntriesProvided);
+        if config_path.is_none() {
+            config_path =
+                find_config_file(&std::env::current_dir()?)
+                    .ok();
+        }
+
+        let config = if let Some(config_path) = config_path {
+            read_config(config_path.as_path())?
+        } else if let Some(entry) = cli_entry {
+            WatchrConfig {
+                debounce_ms: 500,
+                entries: vec![entry],
+            }
+        } else {
+            return Err(MainError::NoWatcherEntriesProvided);
+        };
+
+        if config.entries.is_empty() {
+            return Err(MainError::NoWatcherEntriesProvided);
+        }
+
+        if let Some(path) = config
+            .entries
+            .iter()
+            .flat_map(|e| e.dirs.iter())
+            .find(|p| !p.is_dir())
+        {
+            return Err(MainError::DirNotFound(
+                path.to_path_buf(),
+            ));
+        }
+
+        run_watch(config)?;
     }
-
-    if let Some(path) = config
-        .entries
-        .iter()
-        .flat_map(|e| e.dirs.iter())
-        .find(|p| !p.is_dir())
-    {
-        return Err(MainError::DirNotFound(path.to_path_buf()));
-    }
-
-    run_watch(config)?;
-
     Ok(())
 }


### PR DESCRIPTION
## What
Implement `watchr init` command that creates a default config
file with commented examples in cwd it it doesn't already exist.

## Changes
- Added `is_init` method to `cli::Commands` with unit tests
- Wired up `init` command into main
- Added `DEFAULT_CONFIG_TEMPLATE` constant to `init.rs`
- Added `InitError` enum to `init.rs`
- Added `run_init` funtion to `init.rs`

## Why
Users can now run `watchr init` now to get a sample config 
file in cwd.

## Impact 
- Users: `watcher init` now fully functional
- Code: all modules related to init integrated, clear error
  propagation path

## Checklist
- [x] All tests pass
- [x] CI green
- [x] Closes #9 