### PR TITLE
feat: graceful shutdown on Ctrl + C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,10 +71,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -121,6 +136,29 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "equivalent"
@@ -321,6 +359,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +418,21 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -768,6 +833,7 @@ name = "watchr"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "ctrlc",
  "notify-debouncer-full",
  "serde",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0.228", features = ["derive"] }
 toml = "1.1.2"
 thiserror = "2.0.18"
 tempfile = "3.27.0"
+ctrlc = "3.5.2"

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -21,6 +21,9 @@ use crate::entry::WatchrEntry;
 pub enum WatcherError {
     #[error("notify-debouncer error: {0}")]
     Notify(#[from] notify::Error),
+
+    #[error("failed to create shutdown handler: {0}")]
+    SignalHandler(#[from] ctrlc::Error),
 }
 
 #[derive(Debug)]
@@ -33,6 +36,9 @@ pub fn run_watch(
     config: WatchrConfig,
 ) -> Result<(), WatcherError> {
     let (tx, rx) = mpsc_channel();
+
+    create_shutdown_handler(tx.clone())?;
+
     let _debouncers = create_debouncers(
         config.debounce_ms,
         config.entries,
@@ -43,6 +49,15 @@ pub fn run_watch(
     drop(tx);
 
     run_event_loop(rx);
+    Ok(())
+}
+
+fn create_shutdown_handler(
+    tx: Sender<WatchEvent>,
+) -> Result<(), WatcherError> {
+    ctrlc::try_set_handler(move || {
+        let _ = tx.send(WatchEvent::Shutdown);
+    })?;
     Ok(())
 }
 
@@ -137,7 +152,10 @@ fn run_event_loop(rx: Receiver<WatchEvent>) {
                     Err(e) => println!("{:?}", e),
                 }
             }
-            Ok(WatchEvent::Shutdown) => {}
+            Ok(WatchEvent::Shutdown) => {
+                println!("Shutting down gracefully...");
+                break;
+            }
             Err(_) => break,
         }
     }


### PR DESCRIPTION
## What
Implement logic for graceful shutdown on `SIGTERM` or `SIGINT`
using `ctrlc` trait.

## Changes
- Added `ctrcl` dependency 
- Added `SignalHandler` wrapper for `ctrlc::Error` to `WatcherError`
- Added `create_shutdown_handler` function
- Added logic to handle `WatcherEvent::Shutdown` in `run_event_loop`

## Why
`watchr` now shuts down gracefully after dropping debouncers
on SIGINT and SIGTERM.

## Impact
- Code: complete for v0.1.0
- Graceful shutdown on `SIGTERM` and `SIGINT`

## Checklist
- [x] All tests pass
- [x] Closes #7 
- [x] CI green