### PR TITLE
docs: add inline documentation to all modules

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,11 @@
+//! Command-line interface parsing and validation.
+//!
+//! Defines the CLI structure using `clap` and provides methods
+//! to extract configuration from command-line arguments.
+//! It supports two commands:
+//! - `init` for generating config files
+//! - `watch` for starting the file watcher.
+
 use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
@@ -5,50 +13,107 @@ use thiserror::Error;
 
 use crate::entry::WatchrEntry;
 
+/// Command-line interface for watcher.
+///
+/// Main entry point for parsing user commands and flags.
 #[derive(Parser)]
 #[command(name = "watchr")]
 #[command(
     about = "Watch a directory and execute a given command when changes are made to files in it"
 )]
 pub struct Cli {
+    /// The subcommand to execute.
     #[command(subcommand)]
     pub command: Commands,
 }
 
+/// Errors that can occur during CLI argument validation.
 #[derive(Error, Debug)]
 pub enum CliError {
-    #[error("Entry must have atleast cmd and dir")]
+    /// Raised when `--dir` is provided without `--cmd`,
+    /// or vice versa.
+    ///
+    /// In CLI mode, both flags must be provided together.
+    #[error("Entry must include both cmd and dir")]
     MalformedEntry,
 }
 
+/// Available subcommands for `watchr`.
+///
+/// Supports `init` for config file generation and `watch`
+/// for starting the file watcher with optional CLI mode.
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Generate config file
+    /// Generate a `.watchr.toml` template file.
+    ///
+    /// Creates a new config file in the current directory
+    /// with example watcher entries. Errors if the file
+    /// already exists.
     Init,
 
-    /// Watch specified directories for changes to files with
-    /// specified extensions and execute specified command on
-    /// change
+    /// Start watching for file changes.
+    ///
+    /// Can operate in two modes:
+    /// 1. Config mode: reads `.watchr.toml` from current or
+    ///    parent directories
+    /// 2. CLI mode: uses `--dir` and `--cmd` flags to define a
+    ///    single watcher inline
     Watch {
-        /// Directory to watch
+        /// Directory to watch (CLI mode only).
+        ///
+        /// Must be used together with `--cmd`. If provided
+        /// without `--cmd`, returns `CliError::MalformedEntry`.
         dir: Option<PathBuf>,
 
-        /// Path to .watchr.toml config file
-        #[arg(long)]
-        config: Option<PathBuf>,
-
-        /// Extensions of files that should be watched
+        /// File extensions to filter (CLI mode only).
+        ///
+        /// Comma-separated list (e.g., `"rs,toml"`). If omitted,
+        /// all file changes trigger the command.
         #[arg(long)]
         ext: Option<String>,
 
-        /// command that should be executed if changes are made
-        /// to file being watched
+        /// Command to run on file changes (CLI mode only).
+        ///
+        /// Must be together with `--dir`. If provided without
+        /// `--dir`, returns `CliError::MalformedEntry`.
         #[arg(long)]
         cmd: Option<String>,
+
+        /// Explicit path to config file.
+        ///
+        /// Overrides the default config resolution (walk up
+        /// from current directory). Can be combined with CLI
+        /// mode flags.
+        #[arg(long)]
+        config: Option<PathBuf>,
     },
 }
 
 impl Commands {
+    /// Converts CLI arguments into a [`WatchrEntry`] when
+    /// `--dir` and `--cmd` are both provided.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CliError`] if:
+    /// - only one of `--dir` or `--cmd` is provided
+    ///
+    /// # Examples
+    ///
+    ///   ```no_run
+    ///   use watchr::cli::{Commands, CliError};
+    ///   use std::path::PathBuf;
+    ///
+    ///   let cmd = Commands::Watch {
+    ///       dir: Some(PathBuf::from("src/")),
+    ///       ext: Some("rs".to_string()),
+    ///       cmd: Some("cargo test".to_string()),
+    ///       config: None,
+    ///   };
+    ///
+    ///   let entry = cmd.to_entry()?;
+    ///   assert!(entry.is_some());
+    ///   ```
     pub fn to_entry(
         &self,
     ) -> Result<Option<WatchrEntry>, CliError> {
@@ -82,6 +147,29 @@ impl Commands {
         }
     }
 
+    /// Extract the expicit config file path from `--config`
+    /// flag.
+    ///
+    /// Returns `None` for `Init` command or if `--config`
+    /// flag was not provided.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use watchr::cli::Commands;
+    /// use std::path::PathBuf;
+    ///
+    /// let cmd = Commands::Watch {
+    ///     dir: None,
+    ///     ext: None,
+    ///     cmd: None,
+    ///     config: Some(
+    ///         PathBuf::from(".watchr.toml")
+    ///     ),
+    /// };
+    ///
+    /// assert!(cmd.config_path().is_some());
+    /// ```
     pub fn config_path(&self) -> Option<&Path> {
         match self {
             Commands::Init => None,
@@ -91,6 +179,26 @@ impl Commands {
         }
     }
 
+    /// Check if the command is `Init`
+    ///
+    /// Returns `true` if this is `Init`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use watchr::cli::Commands;
+    ///
+    /// let cmd = Commands::Init;
+    /// assert!(cmd.is_init());
+    ///
+    /// let cmd = Commands::Watch {
+    ///     dir: None,
+    ///     ext: None,
+    ///     cmd: None,
+    ///     config: None,
+    /// };
+    /// assert!(!cmd.is_init());
+    /// ```
     pub fn is_init(&self) -> bool {
         match self {
             Commands::Init => true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,7 @@
+//! Configuration file parsing and validation.
+//!
+//! This module handles reading `.watchr.toml` files and
+//! deserializing them into `WatchrConfig` structs.
 use std::fs;
 use std::path::Path;
 
@@ -6,28 +10,84 @@ use thiserror::Error;
 
 use crate::entry::WatchrEntry;
 
+/// Errors that can occur while reading or parsing a configuration
+/// file.
 #[derive(Error, Debug)]
 pub enum ConfigError {
+    /// File system error while reading the configuration file.
+    ///
+    /// Common causes: permission denied, or invalid path.
     #[error("error reading config file: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("error deserialzing config file: {0}")]
+    /// TOML deserialization error while parsing the configuration
+    /// file.
+    #[error("error deserializing config file: {0}")]
     Deserialize(#[from] toml::de::Error),
 }
 
+/// Configuration for watchr.
+///
+/// Deserialized from `.watchr.toml` files. Contains global
+/// settings and a list of watcher entries.
+///
+/// # Examples
+///
+/// ```toml
+/// debounce_ms = 500
+///
+/// [[watcher]]
+/// name = "tests"
+/// dirs = ["src/"]
+/// ext = ["rs"]
+/// command = "cargo test"
+/// ```
 #[derive(Debug, Deserialize)]
 pub struct WatchrConfig {
+    /// Debounce time in milliseconds.
+    ///
+    /// Groups rapid file changes within this window.
+    /// Defaults to 500ms.
     #[serde(default = "default_debounce_ms")]
     pub debounce_ms: u64,
 
+    /// List of watcher entries.
+    ///
+    /// Each entry defines directories to watch, optional
+    /// file extension filters and a command to execute.
+    /// Corresponds to `[[watcher]]` section in TOML.
     #[serde(rename = "watcher")]
     pub entries: Vec<WatchrEntry>,
 }
 
+/// Default debounce time in milliseconds.
+///
+/// Used by serde when `debounce_ms` is not specified
+/// in the config file.
 fn default_debounce_ms() -> u64 {
     500
 }
 
+/// Read and parse a watchr configuration file.
+///
+/// # Arguments
+/// * `path` - Path to the `.watchr.toml` file
+///
+/// # Errors:
+///
+/// Returns a [`ConfigError`] if:
+/// - the file cannot be read or does not exist
+/// - the TOML is invalid or does not match the expected schema.
+///
+/// # Examples
+///
+/// ```no_run
+/// use watchr::config::read_config;
+/// use std::path::Path;
+///
+/// let config = read_config(Path::new(".watchr.toml"))?;
+/// println!("Debounce: {}ms", config.debounce_ms);
+/// ```
 pub fn read_config(
     path: &Path,
 ) -> Result<WatchrConfig, ConfigError> {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,11 +1,50 @@
+//! Watcher entry data structure.
+//!
+//! This module defines `WatchrEntry`, which represents a
+//! single watcher configuration. Each entry specifies
+//! which directories to monitor, optional file extension
+//! filters, and the command to execute on file changes.
+//!
+//! Entries are typically deserialzed from `[[watcher]]`
+//! sections in `.watchr.toml` files or created from CLI
+//! arguments.
 use std::path::PathBuf;
 
 use serde::Deserialize;
 
+/// A single watcher entry defining what to watch and what to run.
+///
+/// Represents one `[[watcher]]` section in the config file.
+///
+/// # Example
+///
+/// ```toml
+/// [[watcher]]
+/// name = "rust-build"
+/// dirs = ["src"]
+/// ext = ["rs"]
+/// command = "cargo build"
+/// ```
 #[derive(Debug, Deserialize)]
 pub struct WatchrEntry {
+    /// Optional descriptive name for this watcher
+    #[allow(dead_code)]
     pub name: Option<String>,
+
+    /// Directories to watch for changes.
+    ///
+    /// Paths may be absolute or relative to the working
+    /// directory.
     pub dirs: Vec<PathBuf>,
+
+    /// File extensions to filter (e.g., ["rs", "toml"]).
+    ///
+    /// File extensions should not include the leading dot.
+    /// If `None`, all file changes trigger the command.
     pub ext: Option<Vec<String>>,
+
+    /// Shell command to execute when files change.
+    ///
+    /// Executed in the current working directory.
     pub command: String,
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,14 +1,34 @@
+//! Configuration file initialization.
+//!
+//! Handles the `init` command.
+//!
+//! Generates a `.watchr.toml` template file in the target
+//! directory.
+//! The template includes comments and example watcher entries
+//! to help users get started quickly.
+//!
+//! See [`InitError`] for failure conditions.
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
 use thiserror::Error;
 
+/// Errors that occur during `init` command execution.
 #[derive(Error, Debug)]
 pub enum InitError {
+    /// Raised if `.watchr.toml` file already exists in
+    /// the target directory.
+    ///
+    /// The `init` command refuses to overwrite existing
+    /// config files to prevent accidental data loss.
     #[error(".watchr.toml already exists")]
     FileAlreadyExists,
 
+    /// Raised when file system operations fail.
+    ///
+    /// Common causes: permission denied, disk full, or
+    /// invalid path.
     #[error("IoError: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -32,6 +52,32 @@ debounce_ms = 500
 # command = "cargo clippy"
 "#;
 
+/// Initialize a `.watchr.toml` in the given directory.
+///
+/// Fails if the file already exists. Does not create parent
+/// directories.
+///
+/// # Arguments
+/// * `path` - Directory where the `.watchr.toml` file will be
+///   created
+///
+/// # Errors
+///
+/// Returns [`InitError`] if:
+/// - `.watchr.toml` already exists
+/// - the directory does not exist, the path is invalid path,
+///   or permission is denied
+///
+/// # Examples
+///
+/// ```no_run
+/// use watchr::init::run_init;
+/// use std::path::Path;
+///
+/// let path = Path::new(".");
+/// run_init(path)?;
+/// assert!(path.join(".watchr.toml").exists());
+/// ```
 pub fn run_init(path: &Path) -> Result<(), InitError> {
     let path = path.join(".watchr.toml");
     if path.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,18 @@
-#![allow(dead_code)]
+//! Entry point and orchestration layer for `watchr`
+//!
+//! # Execution Flow
+//! 1. Parse CLI arguments using CLI module
+//! 2. Determine command (`is_init` function on cli::Commands)
+//!    - `init` -> [`run_init`]
+//!    - `watch` -> [`run_watch`]
+//! 3. Execute the selected command via `run()`
+//! 4. Result `Result<(), MainError>` to the caller
+//!
+//! The main function invokes `run()` and handles any surfaced
+//! errors.
+//!
+//! This module contains no business logic; all functionality
+//! is delegated to command-specific modules
 mod cli;
 mod config;
 mod entry;
@@ -17,33 +31,64 @@ use crate::init::{InitError, run_init};
 use crate::resolver::{ResolverError, find_config_file};
 use crate::watcher::{WatcherError, run_watch};
 
+/// Errors that can occur during `watchr` run.
 #[derive(Error, Debug)]
 enum MainError {
+    /// Wrapper for errors from CLI module.
     #[error("CliError: {0}")]
     CliError(#[from] CliError),
 
+    /// Wrapper for errors from resolver module.
     #[error("ResolverError: {0}")]
     ResolverError(#[from] ResolverError),
 
+    /// Wrapper for errors from config module.
     #[error("ConfigError: {0}")]
     ConfigError(#[from] ConfigError),
 
+    /// Wrapper for errors from watcher module.
     #[error("WatcherError: {0}")]
     WatcherError(#[from] WatcherError),
 
+    /// Raised when file system operations fail.
+    ///
+    /// **Common causes**: permission denied, invalid path, or
+    /// disk full.
     #[error("IoError: {0}")]
     Io(#[from] std::io::Error),
 
+    /// Raised when no watcher entries exist in config file
+    /// (deserialization) or can be resolved from CLI mode.
+    ///
+    /// **Fix**: Ensure your config file includes at least one
+    /// watcher entry, or provide an entry via CLI arguments
     #[error("No watcher entries provided")]
     NoWatcherEntriesProvided,
 
-    #[error("Directory not found: {0}")]
+    /// Raised when directory to watch does not exist
+    ///
+    /// **Fix**: Verify the path exists and is accessible.
+    #[error(
+        "Directory not found: {0} (check if path exists and is accessible)"
+    )]
     DirNotFound(PathBuf),
 
+    /// Wrapper for errors from init module
     #[error("InitError: {0}")]
     InitError(#[from] InitError),
 }
 
+/// Entry point for the `watchr` application.
+///
+/// # Errors
+/// If the application fails during execution (e.g., due to
+/// `run()` returning an error), this function prints the error
+/// to `stderr` and exits with a non-zero status code (1).
+///
+/// # Examples
+/// ```ignore
+/// $ watchr
+/// ```
 fn main() {
     if let Err(e) = run() {
         eprintln!("Error: {}", e);
@@ -51,6 +96,20 @@ fn main() {
     }
 }
 
+/// Main orchestrator for the `watchr` application.
+///
+/// Parses command-line arguments, initializes configuration
+/// file, and starts the file watcher.
+///
+/// # Errors
+///
+/// Returns a [`MainError`] if:
+/// - no watcher entries are provided (either via CLI or
+///   config file).
+/// - a directory specified in the config or CLI does not
+///   exist.
+/// - there is an error reading the config file or parsing
+///   CLI arguments.
 fn run() -> Result<(), MainError> {
     let cli = Cli::parse();
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,13 +1,34 @@
+//! Find the configuration file at the specified directory
+//! or by walking up the directory tree.
 use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
+/// Errors that occur when trying to find the configuration
+/// file.
 #[derive(Debug, Error)]
 pub enum ResolverError {
+    /// Raised if configuration file not found at the specified
+    /// directory or parent directories.
     #[error("config file not found")]
     NotFound,
 }
 
+/// Find the configuration file by checking the specified
+/// directory or walking up the directory tree.
+///
+/// The search starts at `path` and proceeds upward through its
+/// parent directories until the file is found or the filesystem
+/// root is reached.
+///
+/// `path` is expected to be a directory. If a file path is
+/// provided, the search will start from that path directly.
+///
+/// # Errors
+///
+/// Returns a `[ResolverError]` in the following cases:
+/// - If no config file is found in the specified directory
+///   or by walking up the directory tree
 pub fn find_config_file(
     path: &Path,
 ) -> Result<PathBuf, ResolverError> {

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,3 +1,12 @@
+//! File watcher orchestration.
+//!
+//! Provides the implementation for the `watch` command.
+//!
+//! This module initializes filesystem watchers for all
+//! configured entries and dispatches commands when matching
+//! file changes occur.
+//!
+//! See [`WatcherError`] for failure modes.
 use std::path::PathBuf;
 use std::process;
 use std::sync::mpsc::{
@@ -17,21 +26,72 @@ use thiserror::Error;
 use crate::config::WatchrConfig;
 use crate::entry::WatchrEntry;
 
+/// Errors produced during watcher initialization and runtime
+/// setup.
 #[derive(Error, Debug)]
 pub enum WatcherError {
+    /// Failure originating from the notify/debouncer layer.
+    ///
+    /// This includes:
+    /// - Debouncer creation failures
+    /// - Debouncer watch registration failures
     #[error("notify-debouncer error: {0}")]
     Notify(#[from] notify::Error),
 
+    /// Failure when installing the Ctrl+C signal handler.
     #[error("failed to create shutdown handler: {0}")]
     SignalHandler(#[from] ctrlc::Error),
 }
 
+/// Events emitted by the watcher system and consumed by the
+/// event loop.
 #[derive(Debug)]
 pub enum WatchEvent {
+    /// Execute the associated command.
     Command(String),
+
+    /// Terminate the watcher loop gracefully.
     Shutdown,
 }
 
+/// Runs the file watching system.
+///
+/// Initializes:
+/// - A shutdown signal handler (Ctrl+C)
+/// - Debounced filesystem watchers for all configured entries
+/// - The main event loop
+///
+/// This functions blocks until a shutdown event is received.
+///
+/// # Arguments
+/// * `config` - Application configuration containing watcher
+///   entries
+///
+/// # Errors
+///
+/// Returns [`WatcherError`] if:
+/// - The debouncer cannot be created
+/// - A directory cannot be registered for watching
+/// - The signal handler cannot be installed
+///
+/// # Examples
+///
+/// ```no_run
+/// use watchr::entry::WatchrEntry;
+///
+/// let entry = WatchrEntry {
+///     name: "test",
+///     dirs: vec![PathBuf::from(".")],
+///     ext: None,
+///     command: "cargo test".to_string(),
+/// }
+/// let config = WatchrConfig{
+///     debounce_ms: 500,
+///     entries: vec![entry]
+/// }
+///
+/// run_watch(config)?
+/// ```
 pub fn run_watch(
     config: WatchrConfig,
 ) -> Result<(), WatcherError> {
@@ -52,6 +112,25 @@ pub fn run_watch(
     Ok(())
 }
 
+/// Installs a Ctrl+C handler that triggers a graceful shutdown.
+///
+/// When SIGINT or SIGTERM is received, [`WatchEvent::Shutdown`]
+/// message is sent through the provided channel.
+///
+/// # Arguments
+///
+/// * `tx` - Channel sender used to propagate shutdown events
+///
+/// # Errors
+/// Returns [`WatcherError::SignalHandler`] if the handler cannot
+/// be registered.
+///
+/// # Examples
+///
+/// ```no_run
+/// let (tx, _) = std::sync::mpsc::channel();
+/// let ctrlc_handler = create_shutdown_handler(tx)?;
+/// ```
 fn create_shutdown_handler(
     tx: Sender<WatchEvent>,
 ) -> Result<(), WatcherError> {
@@ -61,6 +140,25 @@ fn create_shutdown_handler(
     Ok(())
 }
 
+/// Processes debounced filesystem events and emits commands when
+/// matched.
+///
+/// If no extension filter is configured, any event triggers the
+/// command. Otherwise, only file changes matching one of the
+/// provided extensions will trigger execution.
+///
+/// # Arguments
+/// * `result` - Debounced event result from the notify layer
+/// * `exts` - Optional list of file extensions to filter on
+/// * `command` - Command to execute when a match occurs
+/// * `tx` - Channel sender used to emit [`WatchEvent`]s
+///
+///
+/// # Examples
+/// ```no_run
+/// let (tx, _) = std::sync::mpsc::channel();
+/// handle_events(Ok(vec![]), None, "cargo test".into(), tx);
+/// ```
 fn handle_events(
     result: DebounceEventResult,
     exts: Option<Vec<String>>,
@@ -105,6 +203,43 @@ fn handle_events(
     }
 }
 
+/// Creates and registers filesystem watchers for each entry.
+///
+/// Each entry results in a dedicated debouncer configured with:
+/// - The specified debounce duration
+/// - A callback that filters events and emits commands
+///
+/// # Arguments
+/// * `debounce_ms` - Debounce window in milliseconds
+/// * `entries` - Watch configuration entries
+/// * `tx` - Channel sender used to emit [`WatchEvent`]s
+///
+/// # Returns
+///
+/// A collection of active debouncers. They must be kept alive
+/// for watcher to remain active.
+///
+/// # Errors
+///
+/// Returns [`WatcherError`] if:
+/// - A debouncer cannot be created
+/// - A directory cannot be registered for watching
+///
+/// # Examples
+/// ```no_run
+/// use watchr::entry::WatchrEntry;
+/// use std::path::PathBuf;
+///
+/// let (tx, _) = std::sync::mpsc::channel();
+/// let entry = WatchrEntry{
+///     name: None,
+///     dirs: [PathBuf::from(".")]
+///     ext: None,
+///     command: "cargo test".to_string(),
+/// };
+///
+/// let _ = create_debouncers(500, vec![entry], tx)?;
+/// ```
 fn create_debouncers(
     debounce_ms: u64,
     entries: Vec<WatchrEntry>,
@@ -138,6 +273,23 @@ fn create_debouncers(
     Ok(debouncers)
 }
 
+/// Runs the main event loop, consumeing [`WatchEvent`]s.
+///
+/// Behavior:
+/// - Executes shell commands for [`WatchEvent::Command`]
+/// - Terminates cleanly on [`WatchEvent::Shutdown`]
+/// - Exits if the channel is closed
+///
+/// Commands are executed via `sh -c`.
+///
+/// # Arguments
+/// * `rx` - Channel receiver for incoming [`WatchEvent`]s
+///
+/// # Examples
+/// ```no_run
+/// let (_tx, rx) = std::sync::mpsc::channel();
+/// run_event_loop(rx);
+/// ```
 fn run_event_loop(rx: Receiver<WatchEvent>) {
     loop {
         match rx.recv() {


### PR DESCRIPTION
## What
Added inline documentation to all source files.

## Changes
- Added module-level documentation to all source files
- Documented all public structs, enums, and functions
- Included usage in doc comments
- Documented error variants with context
- Added field-level documentation for structs

## Why
Inline documentation makes codebase more manageable and 
professional. It enables `cargo doc` to generate browsable
API documentation, and helps future contributors understand
the code.

## Impact
- **Documentation**: `cargo doc` now generates complete API 
  documentation
- **Onboarding**: Future contributors can understand modules
  quickly
- **v0.1.0 readiness**: Completes documentation requirements
  for release

## Checklist
- [x] All public items documented
- [x] Module-level docs added to all files
- [x] Examples included where appropriate
- [x] Closes #20 